### PR TITLE
fix: disable Streamlit file watcher to avoid inotify errors

### DIFF
--- a/manifests/frontend/configmap.yaml
+++ b/manifests/frontend/configmap.yaml
@@ -6,3 +6,4 @@ metadata:
     app: frontend
 data:
   BACKEND_URL: "http://backend-service"
+  STREAMLIT_SERVER_FILE_WATCHER_TYPE: "none"


### PR DESCRIPTION
## Summary
- Disable Streamlit file watcher via ConfigMap to prevent inotify instance limit errors

## Testing
- `yamllint manifests/frontend/configmap.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b681def5d4832c98735aafdc674d16