### PR TITLE
fix: update VLLM model name

### DIFF
--- a/manifests/backend/configmap.yaml
+++ b/manifests/backend/configmap.yaml
@@ -12,7 +12,7 @@ data:
   
   # VLLM 설정 (k3s 클러스터 내 VLLM 서비스)
   VLLM_BASE_URL: "http://vllm-service:8000"
-  VLLM_MODEL: "gpt-oss-20b"
+  VLLM_MODEL: "openai/gpt-oss-20b"
   VLLM_MAX_TOKENS: "1000"
   VLLM_TEMPERATURE: "0.7"
   VLLM_TIMEOUT: "60"


### PR DESCRIPTION
## Summary
- use full model identifier for VLLM backend config to avoid 404 errors

## Testing
- `kubectl version --client` *(fails: command not found)*
- `yamllint manifests/backend/configmap.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b695473e70832cb868acf4afdb7644