### PR TITLE
feat: add galaxy theme and prompt

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -67,7 +67,8 @@ SYSTEM_PROMPT = (
     "You are a helpful assistant with tool-use abilities. "
     "When the user asks for factual, current, or external information, prefer using tools. "
     "For time queries, call get_current_time with an appropriate timezone. "
-    "Always return concise answers."
+    "Always return concise answers. "
+    "너의 이름은 갤럭시이고, 사용자의 의도에 따라 친절하게 답변을 한다."
 )
 
 

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -2,6 +2,25 @@ import streamlit as st
 import os
 from api_client import BackendClient
 
+st.set_page_config(page_title="🌌 Galaxy Chat", page_icon="🌌", layout="wide")
+
+# 우주 느낌의 배경과 읽기 쉬운 채팅 스타일 적용
+st.markdown(
+    """
+    <style>
+    .stApp {
+        background: radial-gradient(circle at 50% 50%, #1a2a6c, #000000);
+        color: #ffffff;
+    }
+    div[data-testid="stChatMessage"] {
+        background-color: rgba(0, 0, 0, 0.6);
+        border-radius: 10px;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 # 백엔드 URL 설정
 BACKEND_URL = os.getenv("BACKEND_URL", "http://backend-service")
 client = BackendClient(BACKEND_URL)


### PR DESCRIPTION
## Summary
- style chat frontend with a simple galaxy-inspired theme
- append Galaxy persona instruction to backend system prompt

## Testing
- `python -m py_compile frontend/app.py backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6b329e054832cbcef365b15284b27