### PR TITLE
fix: correct buildkit gc flag

### DIFF
--- a/.github/workflows/vllm-build.yml
+++ b/.github/workflows/vllm-build.yml
@@ -45,11 +45,7 @@ jobs:
         with:
           driver-opts: |
             image=moby/buildkit:v0.13.2
-          buildkitd-flags: |
-            --oci-worker
-            --oci-worker-gc=true
-            --oci-worker-gc-keepstorage=20480
-            --debug=false
+          buildkitd-flags: --oci-worker-gc --oci-worker-gc-keepstorage=20480 --debug=false
 
       # 셀프호스트 시작 전/후 디스크 청소 (안전장치)
       - name: Pre-clean (self-hosted)


### PR DESCRIPTION
## Summary
- fix buildkit garbage collection flag syntax for vLLM workflow

## Testing
- `yamllint .github/workflows/vllm-build.yml` *(command not found)*
- `pip install yamllint` *(failed: Could not find a version that satisfies the requirement)*
- `python - <<'PY'
import yaml, sys
yaml.safe_load(open('.github/workflows/vllm-build.yml'))
print('YAML OK')
PY` *(failed: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68b82455a98c832c92b3e681a0c5d309