### PR TITLE
fix: rename json param to avoid pydantic conflict

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -84,11 +84,16 @@ async def startup() -> None:
             url: str,
             headers: Optional[Dict[str, str]] = None,
             query: Optional[Dict[str, Any]] = None,
-            json: Optional[Any] = None,
+            json_body: Optional[Any] = Field(default=None, alias="json"),
             timeout_s: int = 5,
         ) -> str:
             return await mcp_tools.http_request(
-                method, url, headers=headers, query=query, json=json, timeout_s=timeout_s
+                method,
+                url,
+                headers=headers,
+                query=query,
+                json=json_body,
+                timeout_s=timeout_s,
             )
 
         @tool("time_now")


### PR DESCRIPTION
## Summary
- avoid Pydantic field name conflict in LangChain http_request tool

## Testing
- `pytest`
- `python -m py_compile app.py mcp_tools.py vllm_client.py config.py version.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.104.1)*


------
https://chatgpt.com/codex/tasks/task_e_68b963222e40832c904fe516f2aea91b